### PR TITLE
Feat: Button combos

### DIFF
--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: JD Flamm <judsonwebdesign@gmail.com>
 pkgname=huion-keydial-mini-driver
-pkgver=1.0.1
+pkgver=1.1.0
 pkgrel=1
 pkgdesc="User space driver for Huion Keydial Mini bluetooth device"
 arch=('any')

--- a/packaging/arch/README.md
+++ b/packaging/arch/README.md
@@ -103,7 +103,7 @@ The driver uses automatic connection detection via DBus monitoring:
 ## Package Information
 
 - **Package Name**: `huion-keydial-mini-driver`
-- **Version**: 1.0.1
+- **Version**: 1.1.0
 - **Architecture**: Any (Python package)
 - **License**: MIT
 

--- a/packaging/config.yaml.default
+++ b/packaging/config.yaml.default
@@ -6,12 +6,21 @@ device_address: null  # Will auto-discover if not set
 
 # Key mappings (will be loaded into memory)
 # Format: button_name: "KEY_NAME" or "KEY_MODIFIER+KEY_NAME"
-# Available buttons: BUTTON_1, BUTTON_2, BUTTON_3, BUTTON_4, BUTTON_5, BUTTON_6, BUTTON_7, BUTTON_8
-# Examples:
+# Available buttons: BUTTON_1-BUTTON_18, dial actions: DIAL_CW, DIAL_CCW, DIAL_CLICK
+#
+# Individual buttons:
 #   BUTTON_1: "KEY_F1"                    # Single key
 #   BUTTON_2: "KEY_LEFTCTRL+KEY_C"        # Key combination
 #   BUTTON_3: "KEY_VOLUMEUP"              # Media key
+#
+# Button combinations (NEW!):
+#   BUTTON_1+BUTTON_2: "KEY_LEFTCTRL+KEY_C"      # Two-button combo
+#   BUTTON_1+BUTTON_3: "KEY_LEFTCTRL+KEY_V"      # Another combo
+#   BUTTON_1+BUTTON_2+BUTTON_3: "KEY_LEFTCTRL+KEY_SHIFT+KEY_Z"  # Three-button combo
+#
+# Note: Button order in combos doesn't matter (BUTTON_1+BUTTON_2 = BUTTON_2+BUTTON_1)
 key_mappings:
+  # Individual buttons
   # BUTTON_1: "KEY_F1"
   # BUTTON_2: "KEY_LEFTCTRL+KEY_C"
   # BUTTON_3: "KEY_VOLUMEUP"
@@ -20,6 +29,12 @@ key_mappings:
   # BUTTON_6: "KEY_PLAYPAUSE"
   # BUTTON_7: "KEY_ENTER"
   # BUTTON_8: "KEY_ESC"
+
+  # Button combinations (examples)
+  # BUTTON_1+BUTTON_2: "KEY_LEFTCTRL+KEY_C"          # Copy
+  # BUTTON_1+BUTTON_3: "KEY_LEFTCTRL+KEY_V"          # Paste
+  # BUTTON_2+BUTTON_3: "KEY_LEFTCTRL+KEY_Z"          # Undo
+  # BUTTON_1+BUTTON_2+BUTTON_3: "KEY_LEFTCTRL+KEY_SHIFT+KEY_Z"  # Redo
 
 # Dial settings
 dial_settings:

--- a/packaging/debian/changelog
+++ b/packaging/debian/changelog
@@ -1,3 +1,9 @@
+huion-keydial-mini-driver (1.1.0-1) unstable; urgency=medium
+
+  * Add support for button combinations
+
+ -- JD Flamm <judsonwebdesign@gmail.com>  Mon, 28 Jul 2025 12:00:00 +0000
+
 huion-keydial-mini-driver (1.0.1-1) unstable; urgency=medium
 
   * Fix Bluetooth device filtering to prevent connecting to wrong devices

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ markers = [
     "unit: Unit tests",
     "integration: Integration tests",
     "hid_parser: HID parser specific tests",
+    "combo: Button combo functionality tests",
 ]
 
 [tool.coverage.run]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "huion-keydial-mini-driver"
-version = "1.0.1"
+version = "1.1.0"
 description = "User space driver for Huion Keydial Mini bluetooth device"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/huion_keydial_mini/__init__.py
+++ b/src/huion_keydial_mini/__init__.py
@@ -1,5 +1,5 @@
 """Huion Keydial Mini driver package."""
 
-__version__ = "1.0.1"
+__version__ = "1.1.0"
 __author__ = "JD Flamm"
 __email__ = "judsonwebdesign@gmail.com"

--- a/src/huion_keydial_mini/config.py
+++ b/src/huion_keydial_mini/config.py
@@ -92,11 +92,11 @@ class Config:
         mappings = self.data.get('key_mappings', {})
         if not isinstance(mappings, dict):
             return {}
-        # Ensure all values are strings with proper type checking
+        # Ensure all keys and values are strings with proper type checking
         result: Dict[str, str] = {}
         for k, v in mappings.items():
-            if isinstance(k, str) and v is not None:
-                result[k] = str(v)
+            if isinstance(k, str) and isinstance(v, str) and v:
+                result[k] = v
         return result
 
     @property

--- a/tests/test_combo_config.py
+++ b/tests/test_combo_config.py
@@ -1,0 +1,331 @@
+"""Tests for button combo support in configuration files."""
+
+import pytest
+import tempfile
+import yaml
+from pathlib import Path
+from unittest.mock import Mock, patch, call
+
+from huion_keydial_mini.config import Config
+from huion_keydial_mini.keybind_manager import KeybindManager
+
+
+class TestConfigComboSupport:
+    """Test cases for combo support in configuration files."""
+
+    @pytest.fixture
+    def basic_combo_config_data(self):
+        """Basic config data with combo mappings."""
+        return {
+            'device': {
+                'address': None,
+                'name': 'Huion Keydial Mini',
+            },
+            'key_mappings': {
+                # Individual buttons
+                'BUTTON_1': 'KEY_F1',
+                'BUTTON_2': 'KEY_F2',
+                'BUTTON_3': 'KEY_F3',
+
+                # Button combos
+                'BUTTON_1+BUTTON_2': 'KEY_CTRL+KEY_C',
+                'BUTTON_1+BUTTON_3': 'KEY_CTRL+KEY_V',
+                'BUTTON_2+BUTTON_3': 'KEY_CTRL+KEY_Z',
+                'BUTTON_1+BUTTON_2+BUTTON_3': 'KEY_CTRL+KEY_SHIFT+KEY_Z',
+            },
+            'dial_settings': {
+                'DIAL_CW': 'KEY_VOLUMEUP',
+                'DIAL_CCW': 'KEY_VOLUMEDOWN',
+                'DIAL_CLICK': 'KEY_MUTE',
+                'sensitivity': 1.0,
+            },
+            'uinput': {
+                'device_name': 'Huion Keydial Mini Test',
+            },
+            'debug_mode': True,
+        }
+
+    @pytest.fixture
+    def invalid_combo_config_data(self):
+        """Config data with invalid combo mappings for testing validation."""
+        return {
+            'key_mappings': {
+                # Valid mappings
+                'BUTTON_1': 'KEY_F1',
+                'BUTTON_1+BUTTON_2': 'KEY_CTRL+KEY_C',
+
+                # Invalid mappings (should be ignored)
+                'BUTTON_99': 'KEY_INVALID',                 # Invalid button number
+                'BUTTON_1+BUTTON_99': 'KEY_ALSO_INVALID',   # Invalid button in combo
+                'BUTTON_1+': 'KEY_INCOMPLETE',              # Incomplete combo
+                'INVALID_ACTION': 'KEY_WHATEVER',           # Not a button action
+                '': 'KEY_EMPTY',                            # Empty action ID
+            },
+            'dial_settings': {},
+            'debug_mode': True,
+        }
+
+    @pytest.fixture
+    def unsorted_combo_config_data(self):
+        """Config data with unsorted combo mappings to test normalization."""
+        return {
+            'key_mappings': {
+                # Combos in various orders (should all normalize)
+                'BUTTON_3+BUTTON_1': 'KEY_ALT+KEY_TAB',
+                'BUTTON_2+BUTTON_1+BUTTON_3': 'KEY_CTRL+KEY_SHIFT+KEY_A',
+                'BUTTON_18+BUTTON_1+BUTTON_10': 'KEY_F12',
+                'BUTTON_5+BUTTON_2': 'KEY_ESC',
+            },
+            'dial_settings': {},
+            'debug_mode': True,
+        }
+
+    @pytest.fixture
+    def temp_combo_config_file(self, basic_combo_config_data):
+        """Create a temporary config file with combo mappings."""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
+            yaml.dump(basic_combo_config_data, f)
+            temp_path = f.name
+
+        yield temp_path
+
+        # Cleanup
+        Path(temp_path).unlink(missing_ok=True)
+
+    @pytest.mark.combo
+    def test_config_loads_combo_mappings(self, basic_combo_config_data):
+        """Test that config correctly loads combo mappings."""
+        config = Config(basic_combo_config_data)
+
+        # Verify key_mappings includes both individual and combo mappings
+        key_mappings = config.key_mappings
+
+        # Individual buttons
+        assert key_mappings['BUTTON_1'] == 'KEY_F1'
+        assert key_mappings['BUTTON_2'] == 'KEY_F2'
+        assert key_mappings['BUTTON_3'] == 'KEY_F3'
+
+        # Combo mappings
+        assert key_mappings['BUTTON_1+BUTTON_2'] == 'KEY_CTRL+KEY_C'
+        assert key_mappings['BUTTON_1+BUTTON_3'] == 'KEY_CTRL+KEY_V'
+        assert key_mappings['BUTTON_2+BUTTON_3'] == 'KEY_CTRL+KEY_Z'
+        assert key_mappings['BUTTON_1+BUTTON_2+BUTTON_3'] == 'KEY_CTRL+KEY_SHIFT+KEY_Z'
+
+    @pytest.mark.combo
+    def test_keybind_manager_loads_combos_from_config(self, basic_combo_config_data):
+        """Test that KeybindManager loads combo mappings from config."""
+        config = Config(basic_combo_config_data)
+        manager = KeybindManager(config)
+
+        # Check that individual mappings were loaded
+        individual_mappings = manager.get_individual_mappings()
+        assert 'BUTTON_1' in individual_mappings
+        assert 'BUTTON_2' in individual_mappings
+        assert 'BUTTON_3' in individual_mappings
+
+        # Check that combo mappings were loaded
+        combo_mappings = manager.get_combo_mappings()
+        assert 'BUTTON_1+BUTTON_2' in combo_mappings
+        assert 'BUTTON_1+BUTTON_3' in combo_mappings
+        assert 'BUTTON_2+BUTTON_3' in combo_mappings
+        assert 'BUTTON_1+BUTTON_2+BUTTON_3' in combo_mappings
+
+        # Verify the actual key mappings
+        action = manager.get_action('BUTTON_1+BUTTON_2')
+        assert action.keys == ['KEY_CTRL', 'KEY_C']
+
+        action = manager.get_action('BUTTON_1+BUTTON_2+BUTTON_3')
+        assert action.keys == ['KEY_CTRL', 'KEY_SHIFT', 'KEY_Z']
+
+    @pytest.mark.combo
+    def test_invalid_combo_mappings_ignored_with_warnings(self, invalid_combo_config_data):
+        """Test that invalid combo mappings are ignored with warnings."""
+        with patch('huion_keydial_mini.keybind_manager.logger') as mock_logger:
+            config = Config(invalid_combo_config_data)
+            manager = KeybindManager(config)
+
+            # Verify valid mappings were loaded
+            assert manager.has_combo_mapping('BUTTON_1+BUTTON_2')
+            assert manager.get_action('BUTTON_1') is not None
+
+            # Verify invalid mappings were NOT loaded
+            assert not manager.has_combo_mapping('BUTTON_1+BUTTON_99')
+            assert manager.get_action('BUTTON_99') is None
+            assert manager.get_action('INVALID_ACTION') is None
+
+            # Verify warnings were logged for invalid entries
+            mock_logger.warning.assert_called()
+            warning_calls = [call.args[0] for call in mock_logger.warning.call_args_list]
+
+            # Should have warnings about invalid entries
+            invalid_warnings = [w for w in warning_calls if 'Invalid' in w or 'invalid' in w]
+            assert len(invalid_warnings) > 0
+
+    @pytest.mark.combo
+    def test_combo_normalization_in_config(self, unsorted_combo_config_data):
+        """Test that combo mappings from config are normalized to sorted order."""
+        config = Config(unsorted_combo_config_data)
+        manager = KeybindManager(config)
+
+        # These should be normalized to sorted order
+        expected_normalizations = [
+            ('BUTTON_3+BUTTON_1', 'BUTTON_1+BUTTON_3'),
+            ('BUTTON_2+BUTTON_1+BUTTON_3', 'BUTTON_1+BUTTON_2+BUTTON_3'),
+            ('BUTTON_18+BUTTON_1+BUTTON_10', 'BUTTON_1+BUTTON_10+BUTTON_18'),
+            ('BUTTON_5+BUTTON_2', 'BUTTON_2+BUTTON_5'),
+        ]
+
+        for original, normalized in expected_normalizations:
+            # Original unsorted combo should NOT exist
+            assert not manager.has_combo_mapping(original)
+
+            # Normalized combo SHOULD exist
+            assert manager.has_combo_mapping(normalized), f"Normalized combo {normalized} not found"
+
+            # Verify the mapping
+            action = manager.get_action(normalized)
+            assert action is not None
+
+    @pytest.mark.combo
+    def test_config_file_loading_with_combos(self, temp_combo_config_file):
+        """Test loading combo mappings from actual config file."""
+        config = Config.load(temp_combo_config_file)
+        manager = KeybindManager(config)
+
+        # Verify combos loaded from file
+        assert manager.has_combo_mapping('BUTTON_1+BUTTON_2')
+        assert manager.has_combo_mapping('BUTTON_1+BUTTON_3')
+        assert manager.has_combo_mapping('BUTTON_2+BUTTON_3')
+        assert manager.has_combo_mapping('BUTTON_1+BUTTON_2+BUTTON_3')
+
+        # Verify individual buttons also loaded
+        assert manager.get_action('BUTTON_1') is not None
+        assert manager.get_action('BUTTON_2') is not None
+        assert manager.get_action('BUTTON_3') is not None
+
+    @pytest.mark.combo
+    def test_combo_precedence_over_duplicates(self):
+        """Test handling of potential conflicts between combo and individual mappings."""
+        # Config with potential conflicts
+        config_data = {
+            'key_mappings': {
+                # This could potentially conflict if not handled properly
+                'BUTTON_1': 'KEY_F1',
+                'BUTTON_2': 'KEY_F2',
+                'BUTTON_1+BUTTON_2': 'KEY_CTRL+KEY_C',
+
+                # Test normalization doesn't create conflicts
+                'BUTTON_3+BUTTON_1': 'KEY_ALT+KEY_TAB',  # Should become BUTTON_1+BUTTON_3
+                'BUTTON_1+BUTTON_3': 'KEY_SHIFT+KEY_TAB',  # Potential conflict
+            },
+            'dial_settings': {},
+            'debug_mode': True,
+        }
+
+        config = Config(config_data)
+        manager = KeybindManager(config)
+
+        # Individual mappings should exist
+        assert manager.get_action('BUTTON_1') is not None
+        assert manager.get_action('BUTTON_2') is not None
+
+        # Combo mapping should exist
+        assert manager.has_combo_mapping('BUTTON_1+BUTTON_2')
+
+        # For the duplicate case (BUTTON_3+BUTTON_1 vs BUTTON_1+BUTTON_3)
+        # The last one wins (this is expected YAML behavior)
+        assert manager.has_combo_mapping('BUTTON_1+BUTTON_3')
+        action = manager.get_action('BUTTON_1+BUTTON_3')
+        # Should be the last value defined
+        assert action.keys == ['KEY_SHIFT', 'KEY_TAB']
+
+    @pytest.mark.combo
+    def test_config_combo_descriptions(self, basic_combo_config_data):
+        """Test that combo actions get proper descriptions."""
+        config = Config(basic_combo_config_data)
+        manager = KeybindManager(config)
+
+        # Check combo descriptions are generated properly
+        action = manager.get_action('BUTTON_1+BUTTON_2')
+        assert action.description is not None
+        assert 'BUTTON_1+BUTTON_2' in action.description
+        assert 'KEY_CTRL+KEY_C' in action.description
+
+        action = manager.get_action('BUTTON_1+BUTTON_2+BUTTON_3')
+        assert action.description is not None
+        assert 'BUTTON_1+BUTTON_2+BUTTON_3' in action.description
+
+    @pytest.mark.combo
+    def test_empty_and_none_config_values(self):
+        """Test handling of empty or None values in config combo mappings."""
+        config_data = {
+            'key_mappings': {
+                'BUTTON_1': 'KEY_F1',
+                'BUTTON_1+BUTTON_2': '',        # Empty value
+                'BUTTON_2+BUTTON_3': None,      # None value
+                'BUTTON_1+BUTTON_3': 'KEY_CTRL+KEY_V',  # Valid value
+            },
+            'dial_settings': {},
+            'debug_mode': True,
+        }
+
+        config = Config(config_data)
+        manager = KeybindManager(config)
+
+        # Valid mappings should be loaded
+        assert manager.get_action('BUTTON_1') is not None
+        assert manager.has_combo_mapping('BUTTON_1+BUTTON_3')
+
+        # Empty/None mappings should be ignored
+        assert not manager.has_combo_mapping('BUTTON_1+BUTTON_2')
+        assert not manager.has_combo_mapping('BUTTON_2+BUTTON_3')
+
+    @pytest.mark.combo
+    def test_config_combo_integration_with_dial_settings(self, basic_combo_config_data):
+        """Test that combo mappings coexist properly with dial settings."""
+        config = Config(basic_combo_config_data)
+        manager = KeybindManager(config)
+
+        # Verify dial settings loaded
+        assert manager.get_action('DIAL_CW') is not None
+        assert manager.get_action('DIAL_CCW') is not None
+        assert manager.get_action('DIAL_CLICK') is not None
+
+        # Verify combo mappings loaded
+        assert manager.has_combo_mapping('BUTTON_1+BUTTON_2')
+
+        # Verify individual button mappings loaded
+        assert manager.get_action('BUTTON_1') is not None
+
+        # Check total count includes all types
+        all_mappings = manager.get_all_actions()
+        combo_count = len(manager.get_combo_mappings())
+        individual_count = len(manager.get_individual_mappings())
+
+        # Should have individual buttons + dial actions + combos
+        assert len(all_mappings) == individual_count + combo_count
+        assert combo_count >= 4  # At least 4 combos from basic config
+        assert individual_count >= 6  # At least 3 buttons + 3 dial actions
+
+    @pytest.mark.combo
+    def test_config_type_validation_with_combos(self):
+        """Test that config type validation works with combo mappings."""
+        # Test non-string values in combo mappings
+        config_data = {
+            'key_mappings': {
+                'BUTTON_1': 123,  # Invalid type (should be ignored)
+                'BUTTON_1+BUTTON_2': 'KEY_CTRL+KEY_C',  # Valid
+                456: 'KEY_F1',    # Invalid key type (should be ignored)
+                'BUTTON_2+BUTTON_3': ['KEY_CTRL', 'KEY_Z'],  # Invalid type (should be ignored)
+            },
+            'dial_settings': {},
+            'debug_mode': True,
+        }
+
+        config = Config(config_data)
+        manager = KeybindManager(config)
+
+        # Only valid string mappings should be loaded
+        assert manager.has_combo_mapping('BUTTON_1+BUTTON_2')
+        assert not manager.get_action('BUTTON_1')  # Invalid type was ignored
+        assert not manager.has_combo_mapping('BUTTON_2+BUTTON_3')  # Invalid type was ignored

--- a/tests/test_combo_hid_parser.py
+++ b/tests/test_combo_hid_parser.py
@@ -1,0 +1,253 @@
+"""Tests for button combo detection in HID parser."""
+
+import pytest
+from unittest.mock import Mock, patch
+
+from huion_keydial_mini.hid_parser import HIDParser, EventType, InputEvent
+from huion_keydial_mini.config import Config
+
+
+class ComboHIDTestData:
+    """Test data for combo functionality."""
+
+    # Individual button presses (type 1 format - bytes 3-5)
+    BUTTON_1_ONLY = bytearray([0x00, 0x00, 0x00, 0x0e, 0x00, 0x00, 0x00, 0x00])  # Button 1 only
+    BUTTON_2_ONLY = bytearray([0x00, 0x00, 0x00, 0x0a, 0x00, 0x00, 0x00, 0x00])  # Button 2 only
+    BUTTON_3_ONLY = bytearray([0x00, 0x00, 0x00, 0x0f, 0x00, 0x00, 0x00, 0x00])  # Button 3 only
+
+    # Two-button combinations
+    BUTTON_1_2 = bytearray([0x00, 0x00, 0x00, 0x0e, 0x0a, 0x00, 0x00, 0x00])     # Buttons 1+2
+    BUTTON_1_3 = bytearray([0x00, 0x00, 0x00, 0x0e, 0x0f, 0x00, 0x00, 0x00])     # Buttons 1+3
+    BUTTON_2_3 = bytearray([0x00, 0x00, 0x00, 0x0a, 0x0f, 0x00, 0x00, 0x00])     # Buttons 2+3
+
+    # Three-button combinations
+    BUTTON_1_2_3 = bytearray([0x00, 0x00, 0x00, 0x0e, 0x0a, 0x0f, 0x00, 0x00])  # Buttons 1+2+3
+
+    # No buttons pressed
+    NO_BUTTONS = bytearray([0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00])
+
+
+@pytest.fixture
+def combo_test_data():
+    """Provide combo test data."""
+    return ComboHIDTestData()
+
+
+@pytest.fixture
+def combo_config():
+    """Create a config with combo mappings."""
+    return Config({
+        'key_mappings': {
+            # Individual buttons
+            'BUTTON_1': 'KEY_F1',
+            'BUTTON_2': 'KEY_F2',
+            'BUTTON_3': 'KEY_F3',
+
+            # Button combos
+            'BUTTON_1+BUTTON_2': 'KEY_CTRL+KEY_C',
+            'BUTTON_1+BUTTON_3': 'KEY_CTRL+KEY_V',
+            'BUTTON_2+BUTTON_3': 'KEY_CTRL+KEY_Z',
+            'BUTTON_1+BUTTON_2+BUTTON_3': 'KEY_CTRL+KEY_SHIFT+KEY_Z',
+        },
+        'dial_settings': {},
+        'debug_mode': True
+    })
+
+
+@pytest.fixture
+def combo_parser(combo_config):
+    """Create a HIDParser with combo support."""
+    return HIDParser(combo_config)
+
+
+class TestComboHIDParser:
+    """Test cases for combo detection in HID parser."""
+
+    @pytest.mark.combo
+    def test_combo_parser_initialization(self, combo_parser):
+        """Test combo parser initialization."""
+        assert combo_parser.peak_buttons_this_session == set()
+        assert combo_parser.key_event_triggered is False
+        assert combo_parser.previous_state == {}
+
+    @pytest.mark.combo
+    def test_single_button_press_release(self, combo_parser, combo_test_data):
+        """Test individual button press/release generates correct events."""
+        # Press button 1
+        events = combo_parser._parse_button_events(combo_test_data.BUTTON_1_ONLY)
+        assert events == []  # No events on press
+        assert combo_parser.peak_buttons_this_session == {'BUTTON_1'}
+        assert combo_parser.key_event_triggered is False
+
+        # Release button 1
+        events = combo_parser._parse_button_events(combo_test_data.NO_BUTTONS)
+        assert len(events) == 2  # Press + Release
+        assert events[0].event_type == EventType.KEY_PRESS
+        assert events[0].key_code == 'BUTTON_1'
+        assert events[1].event_type == EventType.KEY_RELEASE
+        assert events[1].key_code == 'BUTTON_1'
+        assert combo_parser.key_event_triggered is True
+        assert combo_parser.peak_buttons_this_session == set()
+
+    @pytest.mark.combo
+    def test_two_button_combo_sequence(self, combo_parser, combo_test_data):
+        """Test two-button combo triggers correctly."""
+        # Press button 1
+        events = combo_parser._parse_button_events(combo_test_data.BUTTON_1_ONLY)
+        assert events == []
+        assert combo_parser.peak_buttons_this_session == {'BUTTON_1'}
+
+        # Press button 2 (while 1 held)
+        events = combo_parser._parse_button_events(combo_test_data.BUTTON_1_2)
+        assert events == []
+        assert combo_parser.peak_buttons_this_session == {'BUTTON_1', 'BUTTON_2'}
+        assert combo_parser.key_event_triggered is False
+
+        # Release button 1 (should trigger combo)
+        events = combo_parser._parse_button_events(combo_test_data.BUTTON_2_ONLY)
+        assert len(events) == 2  # Press + Release of combo
+        assert events[0].event_type == EventType.KEY_PRESS
+        assert events[0].key_code == 'BUTTON_1+BUTTON_2'
+        assert events[1].event_type == EventType.KEY_RELEASE
+        assert events[1].key_code == 'BUTTON_1+BUTTON_2'
+        assert combo_parser.key_event_triggered is True
+
+        # Release button 2 (should not trigger anything)
+        events = combo_parser._parse_button_events(combo_test_data.NO_BUTTONS)
+        assert events == []  # No events due to key_event_triggered flag
+
+    @pytest.mark.combo
+    def test_three_button_combo_sequence(self, combo_parser, combo_test_data):
+        """Test three-button combo triggers correctly."""
+        # Build up to three buttons
+        combo_parser._parse_button_events(combo_test_data.BUTTON_1_ONLY)
+        combo_parser._parse_button_events(combo_test_data.BUTTON_1_2)
+        combo_parser._parse_button_events(combo_test_data.BUTTON_1_2_3)
+
+        assert combo_parser.peak_buttons_this_session == {'BUTTON_1', 'BUTTON_2', 'BUTTON_3'}
+
+        # Release one button (should trigger 3-button combo)
+        events = combo_parser._parse_button_events(combo_test_data.BUTTON_1_2)
+        assert len(events) == 2
+        assert events[0].key_code == 'BUTTON_1+BUTTON_2+BUTTON_3'
+
+    @pytest.mark.combo
+    def test_combo_id_generation(self, combo_parser):
+        """Test combo ID generation and normalization."""
+        # Test sorted combo ID generation
+        result = combo_parser._generate_combo_id({'BUTTON_3', 'BUTTON_1', 'BUTTON_2'})
+        assert result == 'BUTTON_1+BUTTON_2+BUTTON_3'
+
+        # Test empty set
+        result = combo_parser._generate_combo_id(set())
+        assert result == ''
+
+        # Test single button (not really a combo)
+        result = combo_parser._generate_combo_id({'BUTTON_1'})
+        assert result == 'BUTTON_1'
+
+    @pytest.mark.combo
+    def test_rapid_fire_combos(self, combo_parser, combo_test_data):
+        """Test rapid-fire combo scenario (hold button 1, tap others)."""
+        # Press button 1
+        combo_parser._parse_button_events(combo_test_data.BUTTON_1_ONLY)
+
+        # Press button 2, release button 2 (should trigger BUTTON_1+BUTTON_2)
+        combo_parser._parse_button_events(combo_test_data.BUTTON_1_2)
+        events = combo_parser._parse_button_events(combo_test_data.BUTTON_1_ONLY)
+        assert len(events) == 2
+        assert events[0].key_code == 'BUTTON_1+BUTTON_2'
+
+        # Now press button 3, release button 3 (should trigger BUTTON_1+BUTTON_3)
+        combo_parser._parse_button_events(combo_test_data.BUTTON_1_3)
+        events = combo_parser._parse_button_events(combo_test_data.BUTTON_1_ONLY)
+        assert len(events) == 2
+        assert events[0].key_code == 'BUTTON_1+BUTTON_3'
+
+        # Release button 1 (session ends, no more events)
+        events = combo_parser._parse_button_events(combo_test_data.NO_BUTTONS)
+        assert events == []
+
+    @pytest.mark.combo
+    def test_key_event_triggered_reset_on_new_button(self, combo_parser, combo_test_data):
+        """Test that key_event_triggered resets when new buttons are pressed."""
+        # Trigger a combo first
+        combo_parser._parse_button_events(combo_test_data.BUTTON_1_ONLY)
+        combo_parser._parse_button_events(combo_test_data.BUTTON_1_2)
+        combo_parser._parse_button_events(combo_test_data.BUTTON_2_ONLY)  # Triggers combo
+        assert combo_parser.key_event_triggered is True
+
+        # Press a new button (should reset flag)
+        combo_parser._parse_button_events(combo_test_data.BUTTON_2_3)
+        assert combo_parser.key_event_triggered is False
+
+    @pytest.mark.combo
+    def test_peak_button_tracking_with_different_combinations(self, combo_parser, combo_test_data):
+        """Test peak button tracking with various button combinations."""
+        # Start with button 1
+        combo_parser._parse_button_events(combo_test_data.BUTTON_1_ONLY)
+        assert combo_parser.peak_buttons_this_session == {'BUTTON_1'}
+
+        # Add button 2 (new peak)
+        combo_parser._parse_button_events(combo_test_data.BUTTON_1_2)
+        assert combo_parser.peak_buttons_this_session == {'BUTTON_1', 'BUTTON_2'}
+
+        # Change to button 1+3 (different combination, same size)
+        combo_parser._parse_button_events(combo_test_data.BUTTON_1_3)
+        assert combo_parser.peak_buttons_this_session == {'BUTTON_1', 'BUTTON_3'}
+
+        # Add button 2 back (new peak with 3 buttons)
+        combo_parser._parse_button_events(combo_test_data.BUTTON_1_2_3)
+        assert combo_parser.peak_buttons_this_session == {'BUTTON_1', 'BUTTON_2', 'BUTTON_3'}
+
+    @pytest.mark.combo
+    def test_session_reset_conditions(self, combo_parser, combo_test_data):
+        """Test when combo sessions reset correctly."""
+        # Build up a combo session
+        combo_parser._parse_button_events(combo_test_data.BUTTON_1_2)
+        combo_parser._parse_button_events(combo_test_data.BUTTON_1_ONLY)  # Trigger combo
+
+        assert combo_parser.peak_buttons_this_session == {'BUTTON_1', 'BUTTON_2'}
+        assert combo_parser.key_event_triggered is True
+
+        # Release all buttons (should reset everything)
+        combo_parser._parse_button_events(combo_test_data.NO_BUTTONS)
+        assert combo_parser.peak_buttons_this_session == set()
+        assert combo_parser.key_event_triggered is False
+
+    @pytest.mark.combo
+    def test_combo_normalization_consistency(self, combo_parser):
+        """Test that combo ID normalization is consistent regardless of input order."""
+        # Test various orders of the same buttons
+        combinations = [
+            {'BUTTON_1', 'BUTTON_2', 'BUTTON_3'},
+            {'BUTTON_3', 'BUTTON_1', 'BUTTON_2'},
+            {'BUTTON_2', 'BUTTON_3', 'BUTTON_1'},
+        ]
+
+        expected = 'BUTTON_1+BUTTON_2+BUTTON_3'
+        for combo in combinations:
+            result = combo_parser._generate_combo_id(combo)
+            assert result == expected, f"Combo {combo} should normalize to {expected}, got {result}"
+
+    @pytest.mark.combo
+    def test_no_mapping_no_event(self, combo_parser, combo_test_data):
+        """Test that combinations without mappings don't generate events."""
+        # Create parser without combo mappings
+        no_combo_config = Config({
+            'key_mappings': {
+                'BUTTON_1': 'KEY_F1',  # Only individual mappings
+                'BUTTON_2': 'KEY_F2',
+            },
+            'dial_settings': {},
+            'debug_mode': True
+        })
+        parser = HIDParser(no_combo_config)
+
+        # Try combo sequence
+        parser._parse_button_events(combo_test_data.BUTTON_1_2)
+        events = parser._parse_button_events(combo_test_data.BUTTON_1_ONLY)
+
+        # Should not generate combo events since no mapping exists
+        assert events == []
+        assert parser.key_event_triggered is False

--- a/tests/test_combo_keydialctl.py
+++ b/tests/test_combo_keydialctl.py
@@ -1,0 +1,268 @@
+"""Tests for button combo handling in keydialctl CLI."""
+
+import pytest
+import asyncio
+import tempfile
+import os
+from unittest.mock import Mock, patch, AsyncMock
+from pathlib import Path
+
+from huion_keydial_mini.keybind_manager import send_command, KeybindManager
+from huion_keydial_mini.config import Config
+
+
+class TestKeydialctlComboHandling:
+    """Test cases for keydialctl combo functionality."""
+
+    @pytest.fixture
+    def mock_socket_path(self):
+        """Mock socket path for testing."""
+        return "/tmp/test_keydial.sock"
+
+    @pytest.fixture
+    def combo_config(self):
+        """Create a test config with combo support."""
+        return Config({
+            'key_mappings': {
+                'BUTTON_1': 'KEY_F1',
+                'BUTTON_2': 'KEY_F2',
+                'BUTTON_1+BUTTON_2': 'KEY_CTRL+KEY_C',
+                'BUTTON_1+BUTTON_3': 'KEY_CTRL+KEY_V',
+                'BUTTON_2+BUTTON_3': 'KEY_CTRL+KEY_Z',
+            },
+            'dial_settings': {},
+            'debug_mode': True
+        })
+
+    @pytest.fixture
+    def keybind_manager(self, combo_config):
+        """Create a keybind manager for testing."""
+        return KeybindManager(combo_config)
+
+    @pytest.mark.combo
+    @pytest.mark.asyncio
+    async def test_send_combo_bind_command(self, mock_socket_path):
+        """Test sending combo bind command via socket."""
+        # Mock the socket communication
+        mock_reader = AsyncMock()
+        mock_writer = AsyncMock()
+        mock_reader.readline.return_value = b'{"status": "success", "message": "Binding set"}\n'
+
+        with patch('huion_keydial_mini.keybind_manager.asyncio.open_unix_connection') as mock_connect:
+            mock_connect.return_value = (mock_reader, mock_writer)
+
+            command = {
+                'command': 'set_binding',
+                'action_id': 'BUTTON_1+BUTTON_2',
+                'action': {
+                    'type': 'keyboard',
+                    'keys': ['KEY_CTRL', 'KEY_C'],
+                    'description': 'BUTTON_1+BUTTON_2 -> KEY_CTRL+KEY_C'
+                }
+            }
+
+            response = await send_command(mock_socket_path, command)
+
+            # Verify the command was sent correctly
+            mock_writer.write.assert_called_once()
+            written_data = mock_writer.write.call_args[0][0].decode('utf-8')
+            import json
+            sent_command = json.loads(written_data)
+
+            assert sent_command['action_id'] == 'BUTTON_1+BUTTON_2'
+            assert sent_command['action']['keys'] == ['KEY_CTRL', 'KEY_C']
+            assert response['status'] == 'success'
+
+    @pytest.mark.combo
+    def test_combo_id_validation_valid_combos(self, keybind_manager):
+        """Test validation of valid combo action IDs."""
+        valid_combos = [
+            'BUTTON_1+BUTTON_2',
+            'BUTTON_1+BUTTON_3',
+            'BUTTON_2+BUTTON_3',
+            'BUTTON_1+BUTTON_2+BUTTON_3',
+            'BUTTON_10+BUTTON_18',  # Edge case with high numbers
+        ]
+
+        for combo_id in valid_combos:
+            normalized = keybind_manager._validate_and_normalize_action_id(combo_id)
+            assert normalized is not None, f"Valid combo {combo_id} was rejected"
+
+            # Check normalization (should be sorted)
+            buttons = combo_id.split('+')
+            expected = '+'.join(sorted(buttons))
+            assert normalized == expected
+
+    @pytest.mark.combo
+    def test_combo_id_validation_invalid_combos(self, keybind_manager):
+        """Test validation rejects invalid combo action IDs."""
+        invalid_combos = [
+            'BUTTON_99',                    # Invalid button number
+            'BUTTON_1+BUTTON_99',          # Contains invalid button
+            'BUTTON_1+',                   # Incomplete combo
+            '+BUTTON_2',                   # Starts with separator
+            'BUTTON_1++BUTTON_2',          # Double separator
+            'BUTTON_1+BUTTON_1',           # Duplicate button
+            'INVALID_BUTTON',              # Not a button at all
+            '',                            # Empty string
+        ]
+
+        for combo_id in invalid_combos:
+            normalized = keybind_manager._validate_and_normalize_action_id(combo_id)
+            assert normalized is None, f"Invalid combo {combo_id} was accepted"
+
+    @pytest.mark.combo
+    def test_combo_id_normalization_order(self, keybind_manager):
+        """Test that combo IDs are normalized to consistent order."""
+        test_cases = [
+            ('BUTTON_3+BUTTON_1', 'BUTTON_1+BUTTON_3'),
+            ('BUTTON_2+BUTTON_1+BUTTON_3', 'BUTTON_1+BUTTON_2+BUTTON_3'),
+            ('BUTTON_18+BUTTON_1+BUTTON_10', 'BUTTON_1+BUTTON_10+BUTTON_18'),
+            ('BUTTON_5+BUTTON_2+BUTTON_8+BUTTON_1', 'BUTTON_1+BUTTON_2+BUTTON_5+BUTTON_8'),
+        ]
+
+        for input_combo, expected_combo in test_cases:
+            normalized = keybind_manager._validate_and_normalize_action_id(input_combo)
+            assert normalized == expected_combo, f"'{input_combo}' should normalize to '{expected_combo}', got '{normalized}'"
+
+    @pytest.mark.combo
+    def test_combo_action_creation(self, keybind_manager):
+        """Test creating combo actions with the keybind manager."""
+        # Create a combo action
+        combo_id = keybind_manager.set_combo_action(
+            ['BUTTON_1', 'BUTTON_2'],
+            ['KEY_CTRL', 'KEY_C'],
+            'Copy action'
+        )
+
+        assert combo_id == 'BUTTON_1+BUTTON_2'
+        assert keybind_manager.has_combo_mapping(combo_id)
+
+        action = keybind_manager.get_action(combo_id)
+        assert action.keys == ['KEY_CTRL', 'KEY_C']
+        assert action.description == 'Copy action'
+
+    @pytest.mark.combo
+    def test_combo_vs_individual_mappings_separation(self, keybind_manager):
+        """Test that combo and individual mappings are properly separated."""
+        # Add some individual and combo mappings
+        keybind_manager.set_combo_action(['BUTTON_1', 'BUTTON_2'], ['KEY_CTRL', 'KEY_C'])
+        keybind_manager.set_combo_action(['BUTTON_1', 'BUTTON_3'], ['KEY_CTRL', 'KEY_V'])
+
+        individual_mappings = keybind_manager.get_individual_mappings()
+        combo_mappings = keybind_manager.get_combo_mappings()
+
+        # Check that we have the expected individual mappings from config
+        individual_keys = set(individual_mappings.keys())
+        expected_individual = {'BUTTON_1', 'BUTTON_2'}
+        assert expected_individual.issubset(individual_keys)
+
+        # Check that we have the expected combo mappings
+        combo_keys = set(combo_mappings.keys())
+        expected_combos = {'BUTTON_1+BUTTON_2', 'BUTTON_1+BUTTON_3'}
+        assert expected_combos.issubset(combo_keys)
+
+        # Ensure no overlap
+        assert individual_keys.isdisjoint(combo_keys)
+
+    @pytest.mark.combo
+    def test_is_combo_action_detection(self, keybind_manager):
+        """Test detection of combo vs individual actions."""
+        test_cases = [
+            ('BUTTON_1', False),
+            ('BUTTON_18', False),
+            ('DIAL_CW', False),
+            ('BUTTON_1+BUTTON_2', True),
+            ('BUTTON_1+BUTTON_2+BUTTON_3', True),
+            ('BUTTON_10+BUTTON_15', True),
+        ]
+
+        for action_id, expected_is_combo in test_cases:
+            result = keybind_manager.is_combo_action(action_id)
+            assert result == expected_is_combo, f"'{action_id}' combo detection failed"
+
+    @pytest.mark.combo
+    @pytest.mark.asyncio
+    async def test_combo_bind_command_processing(self, keybind_manager):
+        """Test processing combo bind commands through the manager."""
+        # Simulate a bind command for a combo
+        command = {
+            'command': 'set_binding',
+            'action_id': 'BUTTON_1+BUTTON_2',
+            'action': {
+                'type': 'keyboard',
+                'keys': ['KEY_CTRL', 'KEY_C'],
+                'description': 'Copy combo'
+            }
+        }
+
+        response = await keybind_manager._cmd_set_binding(command)
+
+        assert response['status'] == 'success'
+        assert 'BUTTON_1+BUTTON_2' in response['message']
+
+        # Verify the binding was created
+        assert keybind_manager.has_combo_mapping('BUTTON_1+BUTTON_2')
+        action = keybind_manager.get_action('BUTTON_1+BUTTON_2')
+        assert action.keys == ['KEY_CTRL', 'KEY_C']
+
+    @pytest.mark.combo
+    @pytest.mark.asyncio
+    async def test_combo_unbind_command_processing(self, keybind_manager):
+        """Test processing combo unbind commands through the manager."""
+        # First create a combo binding
+        keybind_manager.set_combo_action(['BUTTON_1', 'BUTTON_2'], ['KEY_CTRL', 'KEY_C'])
+        assert keybind_manager.has_combo_mapping('BUTTON_1+BUTTON_2')
+
+        # Now remove it
+        command = {
+            'command': 'remove_binding',
+            'action_id': 'BUTTON_1+BUTTON_2'
+        }
+
+        response = await keybind_manager._cmd_remove_binding(command)
+
+        assert response['status'] == 'success'
+        assert 'BUTTON_1+BUTTON_2' in response['message']
+
+        # Verify the binding was removed
+        assert not keybind_manager.has_combo_mapping('BUTTON_1+BUTTON_2')
+
+    @pytest.mark.combo
+    @pytest.mark.asyncio
+    async def test_get_bindings_includes_combos(self, keybind_manager):
+        """Test that get_bindings command includes combo mappings."""
+        # Add a combo mapping
+        keybind_manager.set_combo_action(['BUTTON_1', 'BUTTON_2'], ['KEY_CTRL', 'KEY_C'])
+
+        response = await keybind_manager._cmd_get_bindings()
+
+        assert response['status'] == 'success'
+        bindings = response['bindings']
+
+        # Should include both individual and combo mappings
+        assert 'BUTTON_1' in bindings  # Individual from config
+        assert 'BUTTON_1+BUTTON_2' in bindings  # Combo we added
+
+        combo_binding = bindings['BUTTON_1+BUTTON_2']
+        assert combo_binding['type'] == 'keyboard'
+        assert combo_binding['keys'] == ['KEY_CTRL', 'KEY_C']
+
+    @pytest.mark.combo
+    def test_combo_button_edge_cases(self, keybind_manager):
+        """Test edge cases in combo button handling."""
+        # Test with maximum button numbers
+        valid_high_combo = keybind_manager._validate_and_normalize_action_id('BUTTON_18+BUTTON_17')
+        assert valid_high_combo == 'BUTTON_17+BUTTON_18'
+
+        # Test with minimum button numbers
+        valid_low_combo = keybind_manager._validate_and_normalize_action_id('BUTTON_2+BUTTON_1')
+        assert valid_low_combo == 'BUTTON_1+BUTTON_2'
+
+        # Test single button (should work for individual buttons)
+        single_button = keybind_manager._validate_and_normalize_action_id('BUTTON_1')
+        assert single_button == 'BUTTON_1'
+
+        # Test empty combo (should fail)
+        empty_combo = keybind_manager._validate_and_normalize_action_id('+')
+        assert empty_combo is None


### PR DESCRIPTION
Button combos now supported in v1.1.0!

- Adds button combo support (ex: BUTTON_1+BUTTON_2 does something different than BUTTON_1 or BUTTON_2)

In detail button combinations are used as so:
1. Whenever a button is pressed the driver will keep track of the current combination
2. On button release, the driver will check the combo that was just present for a key-bind. If present, it will execute
3. The driver will no longer activate key-binds until a new button is pressed down, in which case it will start looking for matches once again (so overlapping key-binds aren't activated in the same event)