### PR TITLE
Fix resource leaks and improve error handling

### DIFF
--- a/src/huion_keydial_mini/bluetooth_watcher.py
+++ b/src/huion_keydial_mini/bluetooth_watcher.py
@@ -167,8 +167,9 @@ class BluetoothWatcher:
                 if interface_name == "org.bluez.Device1":
                     if self.debug_mode:
                         logger.debug(f"Processing Device1 property change for {mac_address}")
-                    # Schedule the async handler
-                    asyncio.create_task(self._handle_device_property_change(mac_address, changed_properties))
+                    # Schedule the async handler with error logging
+                    task = asyncio.create_task(self._handle_device_property_change(mac_address, changed_properties))
+                    task.add_done_callback(self._task_done_callback)
                 elif self.debug_mode:
                     logger.debug(f"Ignoring signal for interface: {interface_name}")
 
@@ -177,6 +178,14 @@ class BluetoothWatcher:
             if self.debug_mode:
                 import traceback
                 logger.debug(traceback.format_exc())
+
+    def _task_done_callback(self, task: asyncio.Task):
+        """Log exceptions from fire-and-forget async tasks."""
+        if task.cancelled():
+            return
+        exc = task.exception()
+        if exc:
+            logger.error(f"Error in async task: {exc}")
 
     async def _handle_device_property_change(self, mac_address: str, changed_properties: Dict[str, Any]):
         """Handle device property changes."""

--- a/src/huion_keydial_mini/config.py
+++ b/src/huion_keydial_mini/config.py
@@ -1,9 +1,13 @@
 """Configuration management for the Huion Keydial Mini driver."""
 
+import logging
 import os
 import yaml
 from typing import Optional, Dict, Any, Union, cast
 from pathlib import Path
+
+
+logger = logging.getLogger(__name__)
 
 
 class Config:
@@ -248,21 +252,20 @@ class Config:
 
     def validate(self) -> bool:
         """Validate the current configuration."""
-        try:
-            # Test all property accessors to ensure they work
-            _ = self.device_address
-            _ = self.device_name
-            _ = self.scan_timeout
-            _ = self.connection_timeout
-            _ = self.reconnect_attempts
-            _ = self.auto_reconnect
-            _ = self.uinput_device_name
-            _ = self.key_mappings
-            _ = self.sticky_key_mappings
-            _ = self.dial_settings
-            return True
-        except Exception:
-            return False
+        valid = True
+        properties = [
+            'device_address', 'device_name', 'scan_timeout',
+            'connection_timeout', 'reconnect_attempts', 'auto_reconnect',
+            'uinput_device_name', 'key_mappings', 'sticky_key_mappings',
+            'dial_settings',
+        ]
+        for prop in properties:
+            try:
+                getattr(self, prop)
+            except Exception as e:
+                logger.error(f"Config validation failed for '{prop}': {e}")
+                valid = False
+        return valid
 
     def get_effective_config(self) -> Dict[str, Any]:
         """Get the effective configuration with all type casting applied."""

--- a/src/huion_keydial_mini/device.py
+++ b/src/huion_keydial_mini/device.py
@@ -112,7 +112,7 @@ class HuionKeydialMini:
                 logger.warning(f"Error disconnecting: {e}")
 
         if self.uinput_handler:
-            pass
+            self.uinput_handler.close()
 
         if self.keybind_manager:
             await self.keybind_manager.stop_socket_server()

--- a/src/huion_keydial_mini/keybind_manager.py
+++ b/src/huion_keydial_mini/keybind_manager.py
@@ -196,7 +196,7 @@ class KeybindManager:
         """Handle client connection to the control socket."""
         try:
             # Read command
-            data = await reader.read(1024)
+            data = await reader.read(4096)
             if not data:
                 return
 
@@ -213,10 +213,18 @@ class KeybindManager:
             await writer.drain()
         except Exception as e:
             logger.error(f"Error handling client command: {e}")
-            error_response = {'status': 'error', 'message': str(e)}
-            writer.write((json.dumps(error_response) + '\n').encode('utf-8'))
-            await writer.drain()
-        # Don't close the connection here - let the client close it
+            try:
+                error_response = {'status': 'error', 'message': str(e)}
+                writer.write((json.dumps(error_response) + '\n').encode('utf-8'))
+                await writer.drain()
+            except Exception:
+                pass
+        finally:
+            try:
+                writer.close()
+                await writer.wait_closed()
+            except Exception:
+                pass
 
     async def _process_command(self, command: Dict[str, Any]) -> Dict[str, Any]:
         """Process a control command."""

--- a/src/huion_keydial_mini/uinput_handler.py
+++ b/src/huion_keydial_mini/uinput_handler.py
@@ -347,6 +347,17 @@ class UInputHandler:
         """Get list of supported key names."""
         return list(self.KEY_MAPPING.keys())
 
+    def close(self):
+        """Close the uinput device and release resources."""
+        if self.device:
+            try:
+                self.device.close()
+                logger.info("Closed uinput device")
+            except Exception as e:
+                logger.warning(f"Error closing uinput device: {e}")
+            finally:
+                self.device = None
+
     def set_keybind_manager(self, keybind_manager: KeybindManager):
         """Set the keybind manager and rebuild capabilities."""
         self.keybind_manager = keybind_manager


### PR DESCRIPTION
## Summary
- **Fix uinput device leak**: `device.py:stop()` had `if self.uinput_handler: pass` — now calls `uinput_handler.close()` to release the `/dev/uinput` file descriptor
- **Fix socket client leak**: `keybind_manager.py:_handle_client()` never closed writer on error/disconnect — now uses `finally` block to always close connections
- **Log async task exceptions**: `bluetooth_watcher.py` fire-and-forget `create_task()` calls now have a done callback that logs exceptions instead of silently dropping them
- **Improve config validation feedback**: `config.py:validate()` now logs which specific property failed instead of returning a bare `False`
- **Increase socket read buffer**: bumped from 1024 to 4096 bytes to handle larger commands

## Why
These are important for a long-running systemd service — file descriptor leaks from uinput and socket connections accumulate over time and can eventually exhaust system resources.

## Test plan
- [x] All 59 existing tests pass
- [ ] Manual test: start service, connect/disconnect device, verify no leaked FDs via `ls /proc/<pid>/fd`
- [ ] Manual test: send malformed JSON to control socket, verify connection is cleaned up

🤖 Generated with [Claude Code](https://claude.com/claude-code)